### PR TITLE
Fix TEST_STR invoking function twice.

### DIFF
--- a/correction/correction.py
+++ b/correction/correction.py
@@ -25,7 +25,7 @@ def hash_test_code(main_path):
             test_code_hash.update(line.encode())
     return test_code_hash.hexdigest()
 
-PROFESSOR_TEST_CODE_HEXDIGEST = 'd4f15976f23772064cbc86d02fb3e7c366e354012eb242b29466f0abe9721cb0'
+PROFESSOR_TEST_CODE_HEXDIGEST = 'baf89724b8363922d57aabb07739353015e20ba720c596c932f593ba0c8b05cb'
 PROFESSOR_CHIFFRE_HEXDIGEST = '60ff41b09e4e1011d3a5f33704ec53df319a248d1de48250a131b809a85cb2db'
 PROFESSOR_CLAIR_HEXDIGEST = '4ef57703aad7ffd9f3129bb46c81a15308f1963e1f12ab00718f3569fde090f3'
 CALLBACKS = pygit2.RemoteCallbacks(credentials=pygit2.KeypairFromAgent("git"))

--- a/test/main.c
+++ b/test/main.c
@@ -14,9 +14,12 @@ int main()
     int resultat = 0;
 
 // Compare deux chaînes de caractères a et b avec strcmp. Incrémente résultat si a est NULL ou si les deux chaînes sont différentes.
-#define TEST_STR(a, b)  if((a == NULL) || (strcmp(a, b) != 0))  \
-                        {                                       \
-                            resultat += 1;                      \
+#define TEST_STR(a, b)  {                                           \
+                            char *s = a;                            \
+                            if((s == NULL) || (strcmp(s, b) != 0))  \
+                            {                                       \
+                                resultat += 1;                      \
+                            }                                       \
                         }
 
 // Compare le contenu de deux fichiers aux chemins a et b avec la commande diff. Incrémente résultat si les fichiers sont différents.


### PR DESCRIPTION
Classic mistake of a macro using a parameters more than once and if it is a function, having the function invoked more than once.
Inserted a temporary variable to avoid the issue. Not the best resolution.
Also had to adjust the digest of test/main.c in the correction script.