### PR TITLE
Bugfixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,16 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "test (MacOS)",
-            "type": "lldb",
-            "request": "launch",
-            "program": "${workspaceFolder}/build/Darwin/test",
-            "args": [],
-            "cwd": "${workspaceFolder}",
-            "preLaunchTask": "make test"
-        },
-        {
-            "name": "test (Linux)",
+            "name": "test (Linux/WSL)",
             "type": "cppdbg",
             "request": "launch",
             "program": "${workspaceFolder}/build/Linux/test",
@@ -27,6 +18,15 @@
             },
             "miDebuggerArgs": "--quiet",
             "targetArchitecture": "x64",
+            "preLaunchTask": "make test"
+        },
+        {
+            "name": "test (MacOS)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/build/Darwin/test",
+            "args": [],
+            "cwd": "${workspaceFolder}",
             "preLaunchTask": "make test"
         }
     ]

--- a/bin/main.c
+++ b/bin/main.c
@@ -44,22 +44,22 @@ int main(int argc, char *argv[])
     {
         if(binaire)
         {
-            dechiffre_Vigenere_flux_binaire(stdin, stdout, cle);
+            dechiffre_Vigenere_flux_binaire(stdout, stdin, cle);
         }
         else
         {
-            dechiffre_Vigenere_flux_texte(stdin, stdout, cle);
+            dechiffre_Vigenere_flux_texte(stdout, stdin, cle);
         }
     }
     else
     {
         if(binaire)
         {
-            chiffre_Vigenere_flux_binaire(stdin, stdout, cle);
+            chiffre_Vigenere_flux_binaire(stdout, stdin, cle);
         }
         else
         {
-            chiffre_Vigenere_flux_texte(stdin, stdout, cle);
+            chiffre_Vigenere_flux_texte(stdout, stdin, cle);
         }
     }
 

--- a/test/main.c
+++ b/test/main.c
@@ -4,6 +4,7 @@
 #include <sys/types.h>
 #include <sys/wait.h>
 
+#include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -184,12 +185,16 @@ int main()
     FILE *fichier_resultat = fopen("build/test/resultat.txt", "w");
     FILE *fichier_clair = fopen("test/clair.txt", "r");
     chiffre_Vigenere_flux_texte(fichier_resultat, fichier_clair, "agatha");
+    fclose(fichier_clair);
+    fclose(fichier_resultat);
     TEST_FILE("build/test/resultat.txt", "test/chiffre.txt");
 
     // Tets dechiffre_Vigenere_flux_texte.
     fichier_resultat = fopen("build/test/resultat.txt", "w");
     FILE *fichier_chiffre = fopen("test/chiffre.txt", "r");
     dechiffre_Vigenere_flux_texte(fichier_resultat, fichier_chiffre, "agatha");
+    fclose(fichier_chiffre);
+    fclose(fichier_resultat);
     TEST_FILE("build/test/resultat.txt", "test/clair.txt");
 
     return resultat;


### PR DESCRIPTION
1. I forgot to call `fclose` on opened files in `test/main.c` before comparing them. This had for effect that the files could still be empty before comparing them. `fclose` forces the flush to disk.

1. Reverse order of parameters when calling [en/de]cryption functions in `bin/main.c.`

1. While I'm at it, I reversed the order of the launch targets since we'll have many more students on Windows+WSL or Linux than macOS.